### PR TITLE
Add configurable external_id name

### DIFF
--- a/sql/migrations.sql
+++ b/sql/migrations.sql
@@ -6,8 +6,8 @@ CREATE SEQUENCE IF NOT EXISTS pg2kafka.outbound_event_queue_id;
 CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
   id            integer NOT NULL DEFAULT nextval('pg2kafka.outbound_event_queue_id'::regclass),
   uuid          uuid NOT NULL DEFAULT uuid_generate_v4(),
-  external_id   varchar(100) NOT NULL,
-  table_name    varchar(100) NOT NULL,
+  external_id   varchar(255) NOT NULL,
+  table_name    varchar(255) NOT NULL,
   statement     varchar(20) NOT NULL,
   data          jsonb NOT NULL,
   created_at    timestamp NOT NULL DEFAULT current_timestamp,
@@ -17,3 +17,13 @@ CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
 CREATE INDEX IF NOT EXISTS outbound_event_queue_id_not_processed_index
 ON pg2kafka.outbound_event_queue (id)
 WHERE processed IS FALSE;
+
+CREATE SEQUENCE IF NOT EXISTS pg2kafka.external_id_relations_id;
+CREATE TABLE IF NOT EXISTS pg2kafka.external_id_relations (
+  id            integer NOT NULL DEFAULT nextval('pg2kafka.external_id_relations_id'::regclass),
+  external_id   varchar(255) NOT NULL,
+  table_name    varchar(255) NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS external_id_relations_unique_table_name_index
+ON pg2kafka.external_id_relations(table_name);

--- a/sql/sql_test.go
+++ b/sql/sql_test.go
@@ -138,14 +138,19 @@ func setupTriggers(t *testing.T) (*sql.DB, *eventqueue.Queue, func()) {
 		name  varchar,
 		email text
 	);
-	SELECT pg2kafka.setup('users');
+	SELECT pg2kafka.setup('users', 'uuid');
 	`)
 	if err != nil {
 		t.Fatalf("Error creating users table: %v", err)
 	}
 
 	return db, eq, func() {
-		_, err := db.Exec("DELETE FROM pg2kafka.outbound_event_queue")
+		_, err := db.Exec("DELETE FROM pg2kafka.external_id_relations")
+		if err != nil {
+			t.Fatalf("failed to clear table: %v", err)
+		}
+
+		_, err = db.Exec("DELETE FROM pg2kafka.outbound_event_queue")
 		if err != nil {
 			t.Fatalf("failed to clear table: %v", err)
 		}

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -10,11 +10,19 @@ DECLARE
   outbound_event record;
   notification json;
 BEGIN
+  SELECT pg2kafka.external_id_relations.external_id INTO external_id
+  FROM pg2kafka.external_id_relations
+  WHERE table_name = TG_TABLE_NAME;
+
   IF TG_OP = 'INSERT' THEN
-    external_id := NEW.uuid; -- TODO: uuid or uid or id?
+    EXECUTE format('SELECT ($1).%s::text', external_id) USING NEW INTO external_id;
+  ELSE
+    EXECUTE format('SELECT ($1).%s::text', external_id) USING OLD INTO external_id;
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
     changes := row_to_json(NEW);
   ELSIF TG_OP = 'UPDATE' THEN
-    external_id := OLD.uuid;
     changes := row_to_json(NEW);
     -- Remove object that didn't change
     FOR col IN SELECT * FROM jsonb_each(row_to_json(OLD)::jsonb) LOOP
@@ -23,7 +31,6 @@ BEGIN
       END IF;
     END LOOP;
   ELSIF TG_OP = 'DELETE' THEN
-    external_id := OLD.uuid;
     changes := '{}'::jsonb;
   END IF;
 
@@ -43,7 +50,7 @@ BEGIN
 END
 $_$;
 
-CREATE OR REPLACE FUNCTION pg2kafka.create_snapshot_events(table_name regclass) RETURNS void
+CREATE OR REPLACE FUNCTION pg2kafka.create_snapshot_events(table_name_ref regclass) RETURNS void
 LANGUAGE plpgsql
 AS $_$
 DECLARE
@@ -52,19 +59,22 @@ DECLARE
   changes jsonb;
   external_id varchar;
 BEGIN
-  query := 'SELECT * FROM ' || table_name;
+  SELECT pg2kafka.external_id_relations.external_id INTO external_id
+  FROM pg2kafka.external_id_relations
+  WHERE pg2kafka.external_id_relations.table_name = table_name_ref::varchar;
+
+  query := 'SELECT * FROM ' || table_name_ref;
 
   FOR rec IN EXECUTE query LOOP
-    external_id := rec.uuid; -- TODO: uuid / uid / id
     changes := json_strip_nulls(row_to_json(rec));
 
-    INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data)
-    VALUES (external_id, table_name, 'SNAPSHOT', changes);
+    INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name_ref, statement, data)
+    VALUES (external_id, table_name_ref, 'SNAPSHOT', changes);
   END LOOP;
 END
 $_$;
 
-CREATE OR REPLACE FUNCTION pg2kafka.setup(table_name regclass) RETURNS void
+CREATE OR REPLACE FUNCTION pg2kafka.setup(table_name_ref regclass, external_id_name text) RETURNS void
 LANGUAGE plpgsql
 AS $_$
 DECLARE
@@ -72,17 +82,20 @@ DECLARE
   lock_query varchar;
   trigger_query varchar;
 BEGIN
-  trigger_name := table_name || '_enqueue_event';
-  lock_query := 'LOCK TABLE ' || table_name || ' IN ACCESS EXCLUSIVE MODE';
+  INSERT INTO pg2kafka.external_id_relations(external_id, table_name)
+  VALUES (external_id_name, table_name_ref);
+
+  trigger_name := table_name_ref || '_enqueue_event';
+  lock_query := 'LOCK TABLE ' || table_name_ref || ' IN ACCESS EXCLUSIVE MODE';
   trigger_query := 'CREATE TRIGGER ' || trigger_name
-    || ' AFTER INSERT OR DElETE OR UPDATE ON ' || table_name
+    || ' AFTER INSERT OR DElETE OR UPDATE ON ' || table_name_ref
     || ' FOR EACH ROW EXECUTE PROCEDURE pg2kafka.enqueue_event()';
 
   -- We aqcuire an exlusive lock on the table to ensure that we do not miss any
   -- events between snapshotting and once the trigger is added.
   EXECUTE lock_query;
 
-  PERFORM pg2kafka.create_snapshot_events(table_name);
+  PERFORM pg2kafka.create_snapshot_events(table_name_ref);
 
   EXECUTE trigger_query;
 END


### PR DESCRIPTION
When calling `pg2kafka.setup` you now provide it with a second argument
to define the "external_id" you want to use as the message key when
procuding the message to Kafka.

Examples:

    pg2kafka.setup('users', 'uuid')
    pg2kafka.setup('products', 'uid')
    pg2kafka.setup('subscriptions', 'user_uuid')


Paired on this together with @jurre to SHARE ALL THE KNOWLEDGE 🎉 