### PR TITLE
Don't create/replace plpgsql for cloudsql support

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -1,5 +1,3 @@
-CREATE OR REPLACE PROCEDURAL LANGUAGE plpgsql;
-
 CREATE OR REPLACE FUNCTION pg2kafka.enqueue_event() RETURNS trigger
 LANGUAGE plpgsql
 AS $_$


### PR DESCRIPTION
```
Error creating triggers: pq: must be owner of language plpgsql
```

I think this might be because of the `CREATE OR REPLACE PROCEDURAL LANGUAGE` statement