### PR TITLE
Always process entire queue

### DIFF
--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func waitForNotification(
 			// We actually receive the payload from the notify here, but in order to
 			// ensure that we never process events out-of-turn, we query the DB for
 			// all unprocessed events.
-			ProcessEvents(p, eq)
+			processQueue(p, eq)
 		case <-time.After(90 * time.Second):
 			go func() {
 				err := l.Ping()


### PR DESCRIPTION
It's possible that a table was just set up while pg2kafka is running, we
should process all messages in the queue in that case, not just 1000.