### PR TITLE
Send notification when snapshot was created

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -71,6 +71,8 @@ BEGIN
     INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data)
     VALUES (external_id, table_name_ref, 'SNAPSHOT', changes);
   END LOOP;
+
+  PERFORM pg_notify('outbound_event_queue', '{ "message": "snapshot created" }');
 END
 $_$;
 


### PR DESCRIPTION
This will ensure that pg2kafka will immediately process the snapshotted
events as soon as they are created, instead of waiting for the first
change to the table to happen.