### PR TITLE
add ability to set custom Kafka topic namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ CREATE TABLE products (
   sku TEXT,
   name TEXT
 );
-````
+```
 
 And it already has some data in it:
 
@@ -101,6 +101,10 @@ UPDATE products SET name = 'Big Red Coffee Mug' WHERE sku = 'CM01-R';
 The producer topics are all in the form of
 `pg2kafka.$database_name.$table_name`, you need to make sure that this topic
 exists, or else pg2kafka will crash.
+
+You can optionally prepend a namespace to the Kafka topic, by setting the
+`TOPIC_NAMESPACE` environment variable. When doing this, the final topic name
+would be `pg2kafka.$namespace.$database_name.$table_name`.
 
 ## Development
 

--- a/main.go
+++ b/main.go
@@ -20,8 +20,8 @@ import (
 )
 
 var (
-	databaseName string
-	version      string
+	topicNamespace string
+	version        string
 )
 
 func main() {
@@ -36,7 +36,7 @@ func main() {
 	logger.Init(conf)
 
 	conninfo := os.Getenv("DATABASE_URL")
-	databaseName = parseDatabaseName(conninfo)
+	topicNamespace = parseTopicNamespace(os.Getenv("TOPIC_NAMESPACE"), parseDatabaseName(conninfo))
 
 	eq, err := eventqueue.New(conninfo)
 	if err != nil {
@@ -171,7 +171,7 @@ func setupProducer() stream.Producer {
 }
 
 func topicName(tableName string) string {
-	return fmt.Sprintf("pg2kafka.%v.%v", databaseName, tableName)
+	return fmt.Sprintf("pg2kafka.%v.%v", topicNamespace, tableName)
 }
 
 func parseDatabaseName(conninfo string) string {
@@ -180,4 +180,13 @@ func parseDatabaseName(conninfo string) string {
 		logger.L.Fatal("Error parsing db connection string", zap.Error(err))
 	}
 	return strings.TrimPrefix(dbURL.Path, "/")
+}
+
+func parseTopicNamespace(topicNamespace string, databaseName string) string {
+	s := databaseName
+	if topicNamespace != "" {
+		s = topicNamespace + "." + s
+	}
+
+	return s
 }

--- a/main_test.go
+++ b/main_test.go
@@ -73,7 +73,7 @@ func TestFetchUnprocessedRecords(t *testing.T) {
 
 func setup(t *testing.T) (*sql.DB, *eventqueue.Queue, func()) {
 	t.Helper()
-	databaseName = "users"
+	topicNamespace = "users"
 	db, err := sql.Open("postgres", os.Getenv("DATABASE_URL"))
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
@@ -121,4 +121,25 @@ func insert(db *sql.DB, events []*eventqueue.Event) error {
 		}
 	}
 	return tx.Commit()
+}
+
+var parseTopicNamespacetests = []struct {
+	in1, in2, out string
+}{
+	{"", "", ""},
+	{"", "world", "world"},
+	{"hello", "", "hello."},
+	{"hello", "world", "hello.world"},
+}
+
+func TestParseTopicNamespace(t *testing.T) {
+	for _, tt := range parseTopicNamespacetests {
+		t.Run(tt.out, func(t *testing.T) {
+			actual := parseTopicNamespace(tt.in1, tt.in2)
+
+			if actual != tt.out {
+				t.Errorf("parseTopicNamespace(%q, %q) => %v, want: %v", tt.in1, tt.in2, actual, tt.out)
+			}
+		})
+	}
 }


### PR DESCRIPTION
This is useful if your database has a generic name like "development"
which would clash with any other databases of other services using the
same generic name.

When setting `TOPIC_NAMESPACE`, the resulting topic name will now consist
of `pg2kafka.$topic_namespace.$database_name.$table_name`.