### PR TITLE
Add info log line when skipping migrations

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,8 @@ func main() {
 		if cerr := eq.ConfigureOutboundEventQueueAndTriggers("./sql"); cerr != nil {
 			logger.L.Fatal("Error configuring outbound_event_queue and triggers", zap.Error(cerr))
 		}
+	} else {
+		logger.L.Info("Not performing database migrations due to missing `PERFORM_MIGRATIONS`.")
 	}
 
 	producer := setupProducer()


### PR DESCRIPTION
If you start pg2kafka without the `PERFORM_MIGRATIONS` flag set, and haven't set up any tables or triggers yet, you'll get an error:

```json
{
  "severity": "EMERGENCY",
  "timestamp": "2017-11-03T16:10:03.526Z",
  "caller": "pg2kafka/main.go:104",
  "message": "Error selecting count",
  "app": "pg2kafka",
  "tier": "stream-processor",
  "production": false,
  "version": "bccd101",
  "environment": "",
  "error": "pq: relation \"pg2kafka.outbound_event_queue\" does not exist",
  "stacktrace": "main.processQueue\n\t/home/jenkins/go/src/github.com/blendle/pg2kafka/main.go:104\nmain.main\n\t/home/jenkins/go/src/github.com/blendle/pg2kafka/main.go:81\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:195"
}
```

There are many things we can do here, with this being the most simple solution, making sure we tell people no migrations are being performed, so they can put one and two together.