### PR TITLE
Ensure pg2kafka.setup idempotency

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -90,6 +90,8 @@ BEGIN
   WHERE pg2kafka.external_id_relations.table_name = table_name_ref::varchar;
 
   IF existing_id != '' THEN
+    RAISE WARNING 'table/external_id relation already exists for %/%. Skipping setup.', table_name_ref, external_id_name;
+
     RETURN;
   END IF;
 

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -80,10 +80,19 @@ CREATE OR REPLACE FUNCTION pg2kafka.setup(table_name_ref regclass, external_id_n
 LANGUAGE plpgsql
 AS $_$
 DECLARE
+  existing_id varchar;
   trigger_name varchar;
   lock_query varchar;
   trigger_query varchar;
 BEGIN
+  SELECT pg2kafka.external_id_relations.external_id INTO existing_id
+  FROM pg2kafka.external_id_relations
+  WHERE pg2kafka.external_id_relations.table_name = table_name_ref::varchar;
+
+  IF existing_id != '' THEN
+    RETURN;
+  END IF;
+
   INSERT INTO pg2kafka.external_id_relations(external_id, table_name)
   VALUES (external_id_name, table_name_ref);
 


### PR DESCRIPTION
When calling `pg2kafka.setup()` twice, it will only create the necessary
trigger once, and will only call `create_snapshot_events` the first time.

This prevents accidental duplicate snapshot events ending up in the
events table.