### PR TITLE
Fix random gometalinter test failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,9 @@
 happyHackin{
   services = [
-    [name: 'postgres', image: 'postgres:9.6']
+    [
+      name: 'postgres',
+      image: 'sameersbn/postgresql:9.6-2',
+      envVars: [containerEnvVar(key: 'DB_NAME', value: 'test1,test2')]
+    ]
   ]
 }

--- a/script/tests/go-test
+++ b/script/tests/go-test
@@ -6,8 +6,11 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-[ -z "$CI" ] || cd "$GOPATH/src/github.com/blendle/pg2kafka"
-
 export DATABASE_URL="postgres://postgres@localhost/postgres?sslmode=disable"
+
+[ -z "$CI" ] || {
+  cd "$GOPATH/src/github.com/blendle/pg2kafka"
+  export DATABASE_URL="postgres://postgres@localhost/test1?sslmode=disable"
+}
 
 go test ./...

--- a/script/tests/gometalinter
+++ b/script/tests/gometalinter
@@ -6,9 +6,12 @@ set -e
 
 cd "$(dirname "$0")/../.."
 
-[ -z "$CI" ] || cd "$GOPATH/src/github.com/blendle/pg2kafka"
-
 export DATABASE_URL="postgres://postgres@localhost/postgres?sslmode=disable"
+
+[ -z "$CI" ] || {
+  cd "$GOPATH/src/github.com/blendle/pg2kafka"
+  export DATABASE_URL="postgres://postgres@localhost/test2?sslmode=disable"
+}
 
 matches=$(grep \
   --ignore-case \
@@ -24,12 +27,15 @@ if [ -n "$matches" ]; then
   exit 1
 fi
 
+# concurrency is set to 1 due to conrrent linters manipulating the DB,
+# which won't work, yet.
 gometalinter \
   --vendor \
   --tests \
   --aggregate \
   --line-length=100 \
   --deadline=300s \
+  --concurrency=1 \
   --exclude='.*_test\.go:.*is unused \(U1000\)' \
   --enable-all \
   --disable=safesql \


### PR DESCRIPTION
Concurrent linter runs are accessing the DB at the same time, causing random failures. This fixes that.