### PR TITLE
Allow NULL values for external IDs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/blendle/go-streamprocessor"
   packages = ["stream","streamclient","streamclient/inmem","streamclient/kafka","streamclient/standardstream"]
-  revision = "648cfe4c5096d6372e170a0708713a32c4dab59c"
+  revision = "3088623c659743ad1306e20846678bf39b9cae01"
 
 [[projects]]
   name = "github.com/bsm/sarama-cluster"

--- a/eventqueue/event_queue.go
+++ b/eventqueue/event_queue.go
@@ -35,7 +35,7 @@ const (
 type Event struct {
 	ID         int             `json:"-"`
 	UUID       string          `json:"uuid"`
-	ExternalID string          `json:"external_id"`
+	ExternalID []byte          `json:"external_id"`
 	TableName  string          `json:"-"`
 	Statement  string          `json:"statement"`
 	Data       json.RawMessage `json:"data"`

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func produceMessages(p stream.Producer, events []*eventqueue.Event, eq *eventque
 		p.Messages() <- &stream.Message{
 			Value:     msg,
 			Topic:     topicName(event.TableName),
-			Key:       []byte(event.ExternalID),
+			Key:       event.ExternalID,
 			Timestamp: event.CreatedAt,
 		}
 

--- a/sql/migrations.sql
+++ b/sql/migrations.sql
@@ -6,7 +6,7 @@ CREATE SEQUENCE IF NOT EXISTS pg2kafka.outbound_event_queue_id;
 CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
   id            integer NOT NULL DEFAULT nextval('pg2kafka.outbound_event_queue_id'::regclass),
   uuid          uuid NOT NULL DEFAULT uuid_generate_v4(),
-  external_id   varchar(255) NOT NULL,
+  external_id   varchar(255),
   table_name    varchar(255) NOT NULL,
   statement     varchar(20) NOT NULL,
   data          jsonb NOT NULL,


### PR DESCRIPTION
`NULL`'d external IDs are perfectly acceptable. With this change:

* `NULL`'s are working as expected
* the eventual partition key is null as well, which means there's no order guarantee (as expected)