### PR TITLE
Remove unnecessary JSON message from pg_notify

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,9 +120,6 @@ func waitForNotification(
 	for {
 		select {
 		case <-l.Notify:
-			// We actually receive the payload from the notify here, but in order to
-			// ensure that we never process events out-of-turn, we query the DB for
-			// all unprocessed events.
 			processQueue(p, eq)
 		case <-time.After(90 * time.Second):
 			go func() {

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -6,7 +6,6 @@ DECLARE
   changes jsonb;
   col record;
   outbound_event record;
-  notification json;
 BEGIN
   SELECT pg2kafka.external_id_relations.external_id INTO external_id
   FROM pg2kafka.external_id_relations
@@ -41,8 +40,7 @@ BEGIN
   VALUES (external_id, TG_TABLE_NAME, TG_OP, changes)
   RETURNING * INTO outbound_event;
 
-  notification := row_to_json(outbound_event);
-  PERFORM pg_notify('outbound_event_queue', notification::text);
+  PERFORM pg_notify('outbound_event_queue', TG_OP);
 
   RETURN NULL;
 END
@@ -72,7 +70,7 @@ BEGIN
     VALUES (external_id, table_name_ref, 'SNAPSHOT', changes);
   END LOOP;
 
-  PERFORM pg_notify('outbound_event_queue', '{ "message": "snapshot created" }');
+  PERFORM pg_notify('outbound_event_queue', 'SNAPSHOT');
 END
 $_$;
 


### PR DESCRIPTION
There used to be an idea to use this data somehow, but at the moment
we're not using it at all, so it's wasteful to construct this object
every time we add an event.