### PR TITLE
Optimize index for large unprocessed outbound_event_queue

### DIFF
--- a/sql/migrations.sql
+++ b/sql/migrations.sql
@@ -14,9 +14,8 @@ CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
   processed     boolean DEFAULT false
 );
 
-CREATE INDEX IF NOT EXISTS outbound_event_queue_id_not_processed_index
-ON pg2kafka.outbound_event_queue (id)
-WHERE processed IS FALSE;
+CREATE INDEX IF NOT EXISTS outbound_event_queue_id_index
+ON pg2kafka.outbound_event_queue (id);
 
 CREATE SEQUENCE IF NOT EXISTS pg2kafka.external_id_relations_id;
 CREATE TABLE IF NOT EXISTS pg2kafka.external_id_relations (


### PR DESCRIPTION
When you create a snapshot for a large table, the index on unprocessed
records will not be used, since practically every row is unprocessed at
this point. This leads to the query planner using a sequential scan,
which is of course very slow on a large table.

The downside of this is that this index will possibly become quite large, and it's only useful in situations where we've just created a large snapshot. I think this might be worth it though.