### PR TITLE
Correctly publish hstore column updates

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -23,7 +23,7 @@ BEGIN
     changes := row_to_json(NEW);
     -- Remove object that didn't change
     FOR col IN SELECT * FROM jsonb_each(row_to_json(OLD)::jsonb) LOOP
-      IF changes @> jsonb_build_object(col.key, col.value) THEN
+      IF changes->col.key = col.value THEN
         changes = changes - col.key;
       END IF;
     END LOOP;


### PR DESCRIPTION
Due to the way we checked how a column was changed we missed updates to
hstore columns. This fixes that.