### PR TITLE
Include previous values in UPDATE and DELETE ops

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,55 +3,88 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:518723f68a6013939a5f71851da62cc3033e27be18944d7b70f9a9228cf464b5"
   name = "github.com/blendle/go-logger"
   packages = ["."]
+  pruneopts = ""
   revision = "2399adc0cd390782c11de7e2dd0bbcd5d4e7a110"
 
 [[projects]]
   branch = "master"
+  digest = "1:12612b84277b7d206241915e41ea5c3afc37bd1b6e2062aa0c31cb7c8b2eef4c"
   name = "github.com/buger/jsonparser"
   packages = ["."]
+  pruneopts = ""
   revision = "5096fddd2cca678b0801ece8513a06e580981fd2"
 
 [[projects]]
+  digest = "1:9ebdaf26c9ef6a4ddaf0815a8da7048e8cc2b4fdf76cb72737245e7230c44015"
   name = "github.com/confluentinc/confluent-kafka-go"
   packages = ["kafka"]
+  pruneopts = ""
   revision = "f696f02dcbb04d95b103c5b848bb15f749a996f7"
   version = "v0.11.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:de80b2e189ad1c264c7fec7c49bc62a724a6118814cf950f7b73f6e883b72c0e"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid",
+  ]
+  pruneopts = ""
   revision = "017e4c14d80628353eaee677a1aeffe47a10c0dc"
 
 [[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:53a6fbacf8dce8fc9cbd4fab6a56eb169be7cb79b9fe601a152d6d9af68312bb"
   name = "go.uber.org/atomic"
   packages = ["."]
+  pruneopts = ""
   revision = "4e336646b2ef9fc6e47be8e21594178f98e5ebcf"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:22c7effcb4da0eacb2bb1940ee173fac010e9ef3c691f5de4b524d538bd980f5"
   name = "go.uber.org/multierr"
   packages = ["."]
+  pruneopts = ""
   revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:cfeddca8479edac1039a52dac1ff6e7a76252ebaecb86680383b0522423b7565"
   name = "go.uber.org/zap"
-  packages = [".","buffer","internal/bufferpool","internal/color","internal/exit","zapcore"]
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore",
+  ]
+  pruneopts = ""
   revision = "35aad584952c3e7020db7b839f6b102de6271f89"
   version = "v1.7.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "00bd593149c4ab1475687b5a9d01feeb83f020cecd28d5ff25b400592b4cff02"
+  input-imports = [
+    "github.com/blendle/go-logger",
+    "github.com/buger/jsonparser",
+    "github.com/confluentinc/confluent-kafka-go/kafka",
+    "github.com/lib/pq",
+    "github.com/pkg/errors",
+    "go.uber.org/zap",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ UPDATE products SET name = 'Big Red Coffee Mug' WHERE sku = 'CM01-R';
   "data": {
     "name": "Big Red Coffee Mug"
   },
+  "previous_data": {
+    "name": "Red Coffee Mug"
+  },
   "created_at": "2017-11-02T16:15:13.94077Z"
 }
 ```

--- a/eventqueue/event_queue.go
+++ b/eventqueue/event_queue.go
@@ -45,7 +45,7 @@ type Event struct {
 	TableName    string          `json:"-"`
 	Statement    string          `json:"statement"`
 	Data         json.RawMessage `json:"data"`
-	PreviousData json.RawMessage `json:"previous_data"`
+	PreviousData json.RawMessage `json:"previous_data,omitempty"`
 	CreatedAt    time.Time       `json:"created_at"`
 	Processed    bool            `json:"-"`
 }
@@ -81,6 +81,7 @@ func (eq *Queue) FetchUnprocessedRecords() ([]*Event, error) {
 
 	messages := []*Event{}
 	for rows.Next() {
+		previousData := &json.RawMessage{}
 		msg := &Event{}
 		err = rows.Scan(
 			&msg.ID,
@@ -89,11 +90,14 @@ func (eq *Queue) FetchUnprocessedRecords() ([]*Event, error) {
 			&msg.TableName,
 			&msg.Statement,
 			&msg.Data,
-			&msg.PreviousData,
+			&previousData,
 			&msg.CreatedAt,
 		)
 		if err != nil {
 			return nil, err
+		}
+		if previousData != nil {
+			msg.PreviousData = *previousData
 		}
 		messages = append(messages, msg)
 	}

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
+var ( // nolint: gochecknoglobals
 	topicNamespace string
 	version        string
 )
@@ -43,6 +43,7 @@ func main() {
 	logger.Init(conf)
 
 	conninfo := os.Getenv("DATABASE_URL")
+	fmt.Println(conninfo)
 	topicNamespace = parseTopicNamespace(os.Getenv("TOPIC_NAMESPACE"), parseDatabaseName(conninfo))
 
 	eq, err := eventqueue.New(conninfo)

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
+// nolint: gocyclo
 func TestFetchUnprocessedRecords(t *testing.T) {
 	db, eq, cleanup := setup(t)
 	defer cleanup()
@@ -19,35 +20,40 @@ func TestFetchUnprocessedRecords(t *testing.T) {
 	// TODO: Use actual trigger to generate this?
 	events := []*eventqueue.Event{
 		{
-			ExternalID: []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
-			TableName:  "users",
-			Statement:  "UPDATE",
-			Data:       []byte(`{ "email": "j@blendle.com" }`),
-			Processed:  true,
+			ExternalID:   []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
+			TableName:    "users",
+			Statement:    "UPDATE",
+			Data:         []byte(`{ "email": "j@blendle.com" }`),
+			PreviousData: []byte(`{}`),
+			Processed:    true,
 		},
 		{
-			ExternalID: []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
-			TableName:  "users",
-			Statement:  "UPDATE",
-			Data:       []byte(`{ "email": "jurre@blendle.com" }`),
+			ExternalID:   []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
+			TableName:    "users",
+			Statement:    "UPDATE",
+			Data:         []byte(`{ "email": "jurre@blendle.com" }`),
+			PreviousData: []byte(`{ "email": "j@blendle.com" }`),
 		},
 		{
-			ExternalID: []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
-			TableName:  "users",
-			Statement:  "UPDATE",
-			Data:       []byte(`{ "email": "jurres@blendle.com" }`),
+			ExternalID:   []byte("fefc72b4-d8df-4039-9fb9-bfcb18066a2b"),
+			TableName:    "users",
+			Statement:    "UPDATE",
+			Data:         []byte(`{ "email": "jurres@blendle.com" }`),
+			PreviousData: []byte(`{ "email": "jurre@blendle.com" }`),
 		},
 		{
-			ExternalID: nil,
-			TableName:  "users",
-			Statement:  "CREATE",
-			Data:       []byte(`{ "email": "bart@simpsons.com" }`),
+			ExternalID:   nil,
+			TableName:    "users",
+			Statement:    "CREATE",
+			Data:         []byte(`{ "email": "bart@simpsons.com" }`),
+			PreviousData: []byte(`{}`),
 		},
 		{
-			ExternalID: nil,
-			TableName:  "users",
-			Statement:  "UPDATE",
-			Data:       []byte(`{ "email": "bartman@simpsons.com" }`),
+			ExternalID:   nil,
+			TableName:    "users",
+			Statement:    "UPDATE",
+			Data:         []byte(`{ "email": "bartman@simpsons.com" }`),
+			PreviousData: []byte(`{ "email": "bart@simpsons.com" }`),
 		},
 	}
 	if err := insert(db, events); err != nil {
@@ -76,6 +82,15 @@ func TestFetchUnprocessedRecords(t *testing.T) {
 		t.Errorf("Data did not match. Expected %v, got %v", "jurre@blendle.com", email)
 	}
 
+	previousEmail, err := jsonparser.GetString(msg.Value, "previous_data", "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if previousEmail != "j@blendle.com" {
+		t.Errorf("Data did not match. Expected %v, got %v", "j@blendle.com", previousEmail)
+	}
+
 	externalID, err := jsonparser.GetString(msg.Value, "external_id")
 	if err != nil {
 		t.Fatal(err)
@@ -93,6 +108,15 @@ func TestFetchUnprocessedRecords(t *testing.T) {
 
 	if email != "bartman@simpsons.com" {
 		t.Errorf("Data did not match. Expected %v, got %v", "bartman@simpsons.com", email)
+	}
+
+	previousEmail, err = jsonparser.GetString(msg.Value, "previous_data", "email")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if previousEmail != "bart@simpsons.com" {
+		t.Errorf("Data did not match. Expected %v, got %v", "bart@simpsons.com", email)
 	}
 
 	if len(msg.Key) != 0 {
@@ -132,8 +156,9 @@ func insert(db *sql.DB, events []*eventqueue.Event) error {
 		return err
 	}
 	statement, err := tx.Prepare(`
-		INSERT INTO pg2kafka.outbound_event_queue (external_id, table_name, statement, data, processed)
-		VALUES ($1, $2, $3, $4, $5)
+		INSERT INTO pg2kafka.outbound_event_queue
+		(external_id, table_name, statement, data, previous_data, processed)
+		VALUES ($1, $2, $3, $4, $5, $6)
 	`)
 	if err != nil {
 		if txerr := tx.Rollback(); txerr != nil {
@@ -143,7 +168,13 @@ func insert(db *sql.DB, events []*eventqueue.Event) error {
 	}
 
 	for _, e := range events {
-		_, serr := statement.Exec(e.ExternalID, e.TableName, e.Statement, e.Data, e.Processed)
+		_, serr := statement.Exec(
+			e.ExternalID,
+			e.TableName,
+			e.Statement,
+			e.Data,
+			e.PreviousData,
+			e.Processed)
 		if serr != nil {
 			if txerr := tx.Rollback(); err != nil {
 				return txerr

--- a/sql/migrations.sql
+++ b/sql/migrations.sql
@@ -10,10 +10,10 @@ CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
   table_name    varchar(255) NOT NULL,
   statement     varchar(20) NOT NULL,
   data          jsonb NOT NULL,
-  previous_data jsonb NOT NULL,
   created_at    timestamp NOT NULL DEFAULT current_timestamp,
   processed     boolean DEFAULT false
 );
+ALTER TABLE pg2kafka.outbound_event_queue ADD COLUMN IF NOT EXISTS previous_data jsonb NULL;
 
 CREATE INDEX IF NOT EXISTS outbound_event_queue_id_index
 ON pg2kafka.outbound_event_queue (id);

--- a/sql/migrations.sql
+++ b/sql/migrations.sql
@@ -10,6 +10,7 @@ CREATE TABLE IF NOT EXISTS pg2kafka.outbound_event_queue (
   table_name    varchar(255) NOT NULL,
   statement     varchar(20) NOT NULL,
   data          jsonb NOT NULL,
+  previous_data jsonb NOT NULL,
   created_at    timestamp NOT NULL DEFAULT current_timestamp,
   processed     boolean DEFAULT false
 );

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -20,7 +20,7 @@ BEGIN
 
   IF TG_OP = 'INSERT' THEN
     changes := row_to_json(NEW);
-    previous := '{}'::jsonb;
+    previous := NULL;
   ELSIF TG_OP = 'UPDATE' THEN
     changes := row_to_json(NEW);
     previous := row_to_json(OLD);
@@ -70,7 +70,7 @@ BEGIN
 
   FOR rec IN EXECUTE query LOOP
     changes := row_to_json(rec);
-    previous := '{}'::jsonb;
+    previous := NULL;
     external_id := changes->>external_id_ref;
 
     INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data, previous_data)

--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -4,6 +4,7 @@ AS $_$
 DECLARE
   external_id varchar;
   changes jsonb;
+  previous jsonb;
   col record;
   outbound_event record;
 BEGIN
@@ -19,16 +20,20 @@ BEGIN
 
   IF TG_OP = 'INSERT' THEN
     changes := row_to_json(NEW);
+    previous := '{}'::jsonb;
   ELSIF TG_OP = 'UPDATE' THEN
     changes := row_to_json(NEW);
+    previous := row_to_json(OLD);
     -- Remove object that didn't change
     FOR col IN SELECT * FROM jsonb_each(row_to_json(OLD)::jsonb) LOOP
       IF changes->col.key = col.value THEN
         changes = changes - col.key;
+        previous = previous - col.key;
       END IF;
     END LOOP;
   ELSIF TG_OP = 'DELETE' THEN
     changes := '{}'::jsonb;
+    previous := row_to_json(OLD);
   END IF;
 
   -- Don't enqueue an event for updates that did not change anything
@@ -36,8 +41,8 @@ BEGIN
     RETURN NULL;
   END IF;
 
-  INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data)
-  VALUES (external_id, TG_TABLE_NAME, TG_OP, changes)
+  INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data, previous_data)
+  VALUES (external_id, TG_TABLE_NAME, TG_OP, changes, previous)
   RETURNING * INTO outbound_event;
 
   PERFORM pg_notify('outbound_event_queue', TG_OP);
@@ -53,6 +58,7 @@ DECLARE
   query text;
   rec record;
   changes jsonb;
+  previous jsonb;
   external_id_ref varchar;
   external_id varchar;
 BEGIN
@@ -64,10 +70,11 @@ BEGIN
 
   FOR rec IN EXECUTE query LOOP
     changes := row_to_json(rec);
+    previous := '{}'::jsonb;
     external_id := changes->>external_id_ref;
 
-    INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data)
-    VALUES (external_id, table_name_ref, 'SNAPSHOT', changes);
+    INSERT INTO pg2kafka.outbound_event_queue(external_id, table_name, statement, data, previous_data)
+    VALUES (external_id, table_name_ref, 'SNAPSHOT', changes, previous);
   END LOOP;
 
   PERFORM pg_notify('outbound_event_queue', 'SNAPSHOT');


### PR DESCRIPTION
In order to write processors that monitors for certain state changes it
can use the previous values to compare a transition.

This PR adds the field `previous_data` to UPDATE and DELETE statements
(it'll add an empty json object for INSERT statements).
I'm not sure about the name of this field. Any other suggestions?

Also had to update some gometalinter issues.

Closes #27